### PR TITLE
Remove leftover local path comments

### DIFF
--- a/client/src/components/PageHeader.jsx
+++ b/client/src/components/PageHeader.jsx
@@ -1,4 +1,4 @@
-// /home/christian/gpt-quiz-app/client/src/components/PageHeader.jsx
+// Displays a styled page header across the application.
 import React from 'react';
 import PropTypes from 'prop-types'; // Optional, but recommended for prop validation
 

--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -1,4 +1,4 @@
-// /home/christian/gpt-quiz-app/client/src/components/ProtectedRoute.jsx
+// Provides route protection by verifying authentication state.
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,4 +1,4 @@
-// /home/christian/gpt-quiz-app/client/src/main.jsx
+// Entry point that mounts the React application.
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';

--- a/client/src/pages/MyAttempts.jsx
+++ b/client/src/pages/MyAttempts.jsx
@@ -1,4 +1,4 @@
-// /home/christian/gpt-quiz-app/client/src/pages/MyAttempts.jsx
+// Page showing the user's previous quiz attempts.
 import { useState, useEffect } from 'react';
 import { apiClient } from '../context/AuthContext'; // Use apiClient
 import PageHeader from '../components/PageHeader';

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,4 +1,4 @@
-// /home/christian/gpt-quiz-app/client/src/pages/Signup.jsx
+// User registration page.
 import React, { useState } from 'react';
 import axios from 'axios';
 import { Link, useNavigate } from 'react-router-dom';

--- a/client/src/pages/Study.jsx
+++ b/client/src/pages/Study.jsx
@@ -1,4 +1,4 @@
-// /home/christian/gpt-quiz-app/client/src/pages/Study.jsx
+// Allows users to study quizzes in an interactive session.
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';


### PR DESCRIPTION
## Summary
- clean up stray path comments in client components and pages

## Testing
- `npm test` (fails: jest not found)
- `npm test` in client (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_684031c1c308832fa9d3f4bb4f4afdc0