### PR TITLE
Fix CORS error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,8 @@ app.use(helmet.frameguard({ action: 'deny' })); // Sets X-Frame-Options: DENY
 const FRONTEND_URLS = [
   'http://10.10.10.2:5173', // Vite dev server
   'http://localhost:5173',  // Localhost dev server
-  process.env.FRONTEND_URL || 'http://10.10.10.2:3000' // Production or custom
+  process.env.FRONTEND_URL || 'http://10.10.10.2:3000', // Production or custom
+  'https://quizcraft.elatron.net' // Deployed frontend
 ];
 
 app.use(cors({


### PR DESCRIPTION
## Summary
- allow the deployed app domain `https://quizcraft.elatron.net` in CORS

## Testing
- `npx --yes eslint "client"` *(fails: no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6840532a5fac832faf45a667ec110839